### PR TITLE
Clock polish

### DIFF
--- a/BeatSaberTweaks/Settings.cs
+++ b/BeatSaberTweaks/Settings.cs
@@ -63,6 +63,11 @@ namespace BeatSaberTweaks
         Vector3 clockRotation = new Vector3(0, 0, 0);
         public static Quaternion ClockRotation { get => Quaternion.Euler(instance.clockRotation); set => instance.clockPosition = value.eulerAngles; }
 
+        [SerializeField]
+        String clockAlignment = "center";
+        public static String ClockAlignment { get => instance.clockAlignment; set => instance.clockAlignment = value; }
+
+
         // Time Spent Clock
         [SerializeField]
         bool showTimeSpentClock = false;
@@ -88,6 +93,10 @@ namespace BeatSaberTweaks
         Vector3 timeSpentClockRotation = new Vector3(0, 0, 0);
         public static Quaternion TimeSpentClockRotation { get => Quaternion.Euler(instance.timeSpentClockRotation); set => instance.timeSpentClockRotation = value.eulerAngles; }
 
+        [SerializeField]
+        String timeSpentClockAlignment = "center";
+        public static String TimeSpentClockAlignment { get => instance.timeSpentClockAlignment; set => instance.timeSpentClockAlignment = value; }
+
         // Ingame Time Spent Clock
         [SerializeField]
         bool showIngameTimeSpentClock = false;
@@ -112,6 +121,10 @@ namespace BeatSaberTweaks
         [SerializeField]
         String ingameTimeSpentClockMessageTemplate = "You've played %TIME% this session.";
         public static String IngameTimeSpentClockMessageTemplate { get => instance.ingameTimeSpentClockMessageTemplate; set => instance.ingameTimeSpentClockMessageTemplate = value; }
+
+        [SerializeField]
+        String ingameTimeSpentClockAlignment = "center";
+        public static String IngameTimeSpentClockAlignment { get => instance.ingameTimeSpentClockAlignment; set => instance.ingameTimeSpentClockAlignment = value; }
 
         // Move Energy Bar
         [SerializeField]

--- a/BeatSaberTweaks/Settings.cs
+++ b/BeatSaberTweaks/Settings.cs
@@ -44,6 +44,10 @@ namespace BeatSaberTweaks
         public static bool ShowClock { get => instance.showclock; set => instance.showclock = value; }
 
         [SerializeField]
+        bool hideClockIngame = false;
+        public static bool HideClockIngame { get => instance.hideClockIngame; set => instance.hideClockIngame = value; }
+
+        [SerializeField]
         bool use24hrClock = false;
         public static bool Use24hrClock { get => instance.use24hrClock; set => instance.use24hrClock = value; }
 

--- a/BeatSaberTweaks/TweakManager.cs
+++ b/BeatSaberTweaks/TweakManager.cs
@@ -178,6 +178,11 @@ namespace BeatSaberTweaks
             showClock.GetValue += delegate { return Settings.ShowClock; };
             showClock.SetValue += delegate (bool value) { Settings.ShowClock = value; };
 
+            var hideClockIngame = subMenu2.AddBool("Hide Clock While Playing");
+            hideClockIngame.GetValue += delegate { return Settings.HideClockIngame; };
+            hideClockIngame.SetValue += delegate (bool value) { Settings.HideClockIngame = value; };
+
+
             var clock24hr = subMenu2.AddBool("24hr Clock");
             clock24hr.GetValue += delegate { return Settings.Use24hrClock; };
             clock24hr.SetValue += delegate (bool value)

--- a/BeatSaberTweaks/Tweaks/InGameClock.cs
+++ b/BeatSaberTweaks/Tweaks/InGameClock.cs
@@ -76,7 +76,9 @@ namespace BeatSaberTweaks
 
                     text = textGO.AddComponent<TextMeshProUGUI>();
                     text.name = "Clock Text";
-                    text.alignment = TextAlignmentOptions.Left;
+
+                    text.alignment = Utilites.TextAlignUtil.textAlignFromString(Settings.ClockAlignment);
+
                     text.fontSize = timeSize;
                     text.text = "";
 

--- a/BeatSaberTweaks/Tweaks/InGameClock.cs
+++ b/BeatSaberTweaks/Tweaks/InGameClock.cs
@@ -22,6 +22,8 @@ namespace BeatSaberTweaks
         private static Quaternion timeRot;
         private static float timeSize;
 
+        private bool _IsPlayerIngame;
+
         float timer = 0;
 
         public static void OnLoad(Transform parent)
@@ -74,14 +76,15 @@ namespace BeatSaberTweaks
 
                     text = textGO.AddComponent<TextMeshProUGUI>();
                     text.name = "Clock Text";
-                    text.alignment = TextAlignmentOptions.Center;
+                    text.alignment = TextAlignmentOptions.Left;
                     text.fontSize = timeSize;
                     text.text = "";
 
                     UpdateClock();
-
+                    
                     ClockCanvas.SetActive(Settings.ShowClock);
                 }
+                _IsPlayerIngame = SceneUtils.isGameScene(scene);
             }
             catch (Exception e)
             {
@@ -91,9 +94,10 @@ namespace BeatSaberTweaks
 
         public void Update()
         {
-            if (ClockCanvas != null && Settings.ShowClock != ClockCanvas.activeSelf)
+            bool shouldShow = Settings.ShowClock && (!_IsPlayerIngame || !Settings.HideClockIngame);
+            if (ClockCanvas != null && shouldShow != ClockCanvas.activeSelf)
             {
-                ClockCanvas.SetActive(Settings.ShowClock);
+                ClockCanvas.SetActive(shouldShow);
             }
 
             timer += Time.deltaTime;

--- a/BeatSaberTweaks/Tweaks/IngameTimeSpentClock.cs
+++ b/BeatSaberTweaks/Tweaks/IngameTimeSpentClock.cs
@@ -75,9 +75,9 @@ namespace BeatSaberTweaks
 
                     _Text = textGO.AddComponent<TextMeshProUGUI>();
                     _Text.name = "IngameTimeSpentClock Text";
-                    _Text.alignment = TextAlignmentOptions.Center;
+                    _Text.alignment = TextAlignmentOptions.Left;
                     _Text.fontSize = _TimeSize;
-                    _Text.text = "You didn't play yet during this session.";
+                    _Text.text = _MessageTemplate.Replace("%TIME%", "0s");
 
                     _IngameTimeSpentClockCanvas.SetActive(Settings.ShowIngameTimeSpentClock);
                 }

--- a/BeatSaberTweaks/Tweaks/IngameTimeSpentClock.cs
+++ b/BeatSaberTweaks/Tweaks/IngameTimeSpentClock.cs
@@ -75,7 +75,7 @@ namespace BeatSaberTweaks
 
                     _Text = textGO.AddComponent<TextMeshProUGUI>();
                     _Text.name = "IngameTimeSpentClock Text";
-                    _Text.alignment = TextAlignmentOptions.Left;
+                    _Text.alignment = Utilites.TextAlignUtil.textAlignFromString(Settings.ClockAlignment);
                     _Text.fontSize = _TimeSize;
                     _Text.text = _MessageTemplate.Replace("%TIME%", "0s");
 

--- a/BeatSaberTweaks/Tweaks/TimeSpentClock.cs
+++ b/BeatSaberTweaks/Tweaks/TimeSpentClock.cs
@@ -76,7 +76,7 @@ namespace BeatSaberTweaks
 
                     _Text = textGO.AddComponent<TextMeshProUGUI>();
                     _Text.name = "TimeSpentClock Text";
-                    _Text.alignment = TextAlignmentOptions.Center;
+                    _Text.alignment = TextAlignmentOptions.Left;
                     _Text.fontSize = _TimeSize;
                     _Text.text = "";
 

--- a/BeatSaberTweaks/Tweaks/TimeSpentClock.cs
+++ b/BeatSaberTweaks/Tweaks/TimeSpentClock.cs
@@ -76,7 +76,7 @@ namespace BeatSaberTweaks
 
                     _Text = textGO.AddComponent<TextMeshProUGUI>();
                     _Text.name = "TimeSpentClock Text";
-                    _Text.alignment = TextAlignmentOptions.Left;
+                    _Text.alignment = Utilites.TextAlignUtil.textAlignFromString(Settings.ClockAlignment); 
                     _Text.fontSize = _TimeSize;
                     _Text.text = "";
 

--- a/BeatSaberTweaks/Utilites/TextAlignUtil.cs
+++ b/BeatSaberTweaks/Utilites/TextAlignUtil.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TMPro;
+
+namespace BeatSaberTweaks.Utilites
+{
+    class TextAlignUtil
+    {
+        public static TextAlignmentOptions textAlignFromString(String opt)
+        {
+            if (String.Equals(Settings.ClockAlignment, "left", StringComparison.OrdinalIgnoreCase)) {
+                return TextAlignmentOptions.Left;
+            }
+            else if (String.Equals(Settings.ClockAlignment, "right", StringComparison.OrdinalIgnoreCase)) {
+                return TextAlignmentOptions.Right;
+            }
+            else {
+                return TextAlignmentOptions.Center;
+            }
+        }
+    }
+}


### PR DESCRIPTION
left-align clocks to make them stop visually jiggling, add HideClockIngame setting for the regular wallclock to match the timespent clocks, stop hardcoding a special message for the ingametimespentclock before you've played a song

the alignment change forces people to re-position their clocks by editing cfg again, which is kinda unfortunate